### PR TITLE
Swap group params

### DIFF
--- a/app/controllers/rollout_control/groups_controller.rb
+++ b/app/controllers/rollout_control/groups_controller.rb
@@ -23,7 +23,7 @@ module RolloutControl
     end
 
     def group
-      group_param = params[:group] || params[:id]
+      group_param = params[:id] || params[:group]
       group_param.to_sym if group_param
     end
   end


### PR DESCRIPTION
I was running into a little problem with this when trying to remove a group.

I'm sending a `DELETE` to `/features/:feature_id/groups/:id` and I am getting:

```
NoMethodError (undefined method `to_sym' for <ActionController::Parameters {} permitted: false>:ActionController::Parameters
Did you mean?  to_s):
```

Rails is treating `params[:group]` as a thing and treating like a `ActionController::Parameters` - so it's there and when it tries to do a `to_sym` it blows up on me.

I thought the simplest fix here that would at least solve my problem is  to just swap these params.

lmk what ya think. 🍻 

Using `gem 'rails', '~> 5.1.4'` btw, not sure if that behavior is present with other versions.