### PR TITLE
(De)activate user using raw rollout identifier (not an OpenStruct)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rollout_control (0.1.0)
+    rollout_control (0.1.2)
       rails
       rollout
 

--- a/app/controllers/rollout_control/users_controller.rb
+++ b/app/controllers/rollout_control/users_controller.rb
@@ -3,8 +3,8 @@ require_dependency 'rollout_control/application_controller'
 module RolloutControl
   class UsersController < ApplicationController
     def create
-      if user
-        rollout.activate_user(feature, user)
+      if user_identifier
+        rollout.activate_user(feature, user_identifier)
         head 204
       else
         head 400
@@ -12,7 +12,7 @@ module RolloutControl
     end
 
     def destroy
-      rollout.deactivate_user(feature, user)
+      rollout.deactivate_user(feature, user_identifier)
       head 204
     end
 
@@ -22,9 +22,8 @@ module RolloutControl
       params[:feature_id].to_sym if params[:feature_id]
     end
 
-    def user
-      user_param = params[:user_id] || params[:id]
-      OpenStruct.new(id: user_param) if user_param
+    def user_identifier
+      (params[:user_id] || params[:id]).presence
     end
   end
 end

--- a/lib/rollout_control/version.rb
+++ b/lib/rollout_control/version.rb
@@ -1,3 +1,3 @@
 module RolloutControl
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end

--- a/test/dummy/config/initializers/rollout.rb
+++ b/test/dummy/config/initializers/rollout.rb
@@ -3,6 +3,6 @@ require 'rollout'
 
 $redis = Redis.new
 RolloutControl.configure do |rc|
-  rc.rollout = Rollout.new(Redis.new)
+  rc.rollout = Rollout.new(Redis.new, id_user_by: :rollout_identifier)
   rc.unprotected = true
 end


### PR DESCRIPTION
This fixes a bug wherein activation/deactivation of rollout(s) for a given user will fail if the application specifies the `id_user_by` option when initializing its `Rollout` instance.

## To run tests

Check out this branch and run `bin/rails test`.