### PR TITLE
Check presence of `params[:group]` when deactivating group rollout

### DIFF
--- a/app/controllers/rollout_control/groups_controller.rb
+++ b/app/controllers/rollout_control/groups_controller.rb
@@ -23,7 +23,7 @@ module RolloutControl
     end
 
     def group
-      group_param = params[:group] || params[:id]
+      group_param = params[:group].presence || params[:id]
       group_param.to_sym if group_param
     end
   end

--- a/test/integration/rollout_control/rollout_control_test.rb
+++ b/test/integration/rollout_control/rollout_control_test.rb
@@ -77,7 +77,7 @@ class RolloutControlTest < ActionDispatch::IntegrationTest
   test "remove group from feature" do
     rollout.deactivate(:extra_sharp_knives)
     rollout.activate_group(:extra_sharp_knives, :experienced_chefs)
-    delete '/rollout/features/extra_sharp_knives/groups/experienced_chefs'
+    delete '/rollout/features/extra_sharp_knives/groups/experienced_chefs', as: :json
     assert_equal 0, rollout.get(:extra_sharp_knives).percentage
     assert_equal [], rollout.get(:extra_sharp_knives).groups
   end


### PR DESCRIPTION
The change being made in this PR avoids an error (_NoMethodError: undefined method \`to_sym' for <ActionController::Parameters {} permitted: false>:ActionController::Parameters_) that otherwise occurs when deactivating a rollout for a group, if the request is made in such a way as to trigger Rails's [parameter wrapping][1] (e.g. if the request is made with `Content-Type: application/json` and the application is configured with `wrap_parameters format: [:json]`).

[1]: https://api.rubyonrails.org/v5.2.3/classes/ActionController/ParamsWrapper.html

# Cause of the bug

When parameter wrapping is triggered (e.g. if the Rails application is configured with `wrap_parameters format: [:json]` and if the request is made with a `Content-Type: application/json` header), it causes `params[:group]` to return an empty instance of `ActionController::Parameters` rather than `nil` [here](https://github.com/hired/rollout_control/blob/v0.1.2/app/controllers/rollout_control/groups_controller.rb#L26), which then causes an error (_NoMethodError: undefined method \`to_sym' for <ActionController::Parameters {} permitted: false>:ActionController::Parameters_) to occur on the next line when we call `#to_sym`: 

```rb
group_param = params[:group] || params[:id]
group_param.to_sym if group_param
```

# Fix

What we want to do instead, when the request doesn't provide a `:group` param, is to access the `:id` param, which this PR accomplishes as so:
```rb
group_param = params[:group].presence || params[:id]
group_param.to_sym if group_param
```

When `params[:group]` is an empty `ActionController::Parameters` instance, then `params[:group].presence` will be falsy (`nil`), and `group_param` will be assigned the value of `params[:id]`, which is expected to be a string identifying the rollout group for which the rollout should be disabled. We can then call `group_param.to_sym` without error.

# Related PR

This PR is an alternative fix for the issue flagged in https://github.com/hired/rollout_control/pull/2 (_Swap group params_), which has a good summary of the issue:

> I'm sending a `DELETE` to `/features/:feature_id/groups/:id` and I am getting:
> 
> ```
> NoMethodError (undefined method `to_sym' for <ActionController::Parameters {} permitted: false>:ActionController::Parameters
> Did you mean?  to_s):
> ```
> 
> Rails is treating `params[:group]` as a thing and treating like a `ActionController::Parameters` - so it's there and when it tries to do a `to_sym` it blows up on me.

## To run tests

Check out this branch, `bundle install`, and then `bin/rails test`.